### PR TITLE
ci: Replace security workflows with org reusable callers

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -2,24 +2,12 @@ name: Secret Scanning
 
 on:
   push:
-    branches: ["**"]
+    branches: ['**']
   pull_request:
     branches: [main]
 
 jobs:
-  scan:
-    name: Scan for Secrets
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: TruffleHog Secret Scan
-        uses: trufflesecurity/trufflehog@v3.93.7
-        if: ${{ github.event_name == 'pull_request' || github.event.before != '0000000000000000000000000000000000000000' }}
-        with:
-          path: ./
-          base: ${{ github.event_name == 'pull_request' && github.event.repository.default_branch || github.event.before }}
-          head: ${{ github.event_name == 'pull_request' && 'HEAD' || github.sha }}
-          extra_args: --only-verified
+  secrets:
+    uses: Forge-Space/.github/.github/workflows/reusable-secret-scan.yml@main
+    permissions:
+      contents: read

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -7,17 +7,6 @@ on:
     paths:
       - .github/workflows/semgrep.yml
 
-permissions:
-  contents: read
-
 jobs:
   semgrep:
-    name: Semgrep Scan
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    container:
-      image: semgrep/semgrep
-    if: (github.actor != 'dependabot[bot]')
-    steps:
-      - uses: actions/checkout@v4
-      - run: semgrep scan --config auto --error
+    uses: Forge-Space/.github/.github/workflows/reusable-semgrep.yml@main

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -10,17 +10,8 @@ permissions:
   security-events: write
 
 jobs:
-  trivy-fs:
-    name: Filesystem Scan
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          scan-type: fs
-          scan-ref: .
-          severity: HIGH,CRITICAL
-          exit-code: 1
-          format: table
+  trivy:
+    uses: Forge-Space/.github/.github/workflows/reusable-trivy.yml@main
+    permissions:
+      contents: read
+      security-events: write


### PR DESCRIPTION
## Summary
- Replace `semgrep.yml` with thin caller to `Forge-Space/.github/.github/workflows/reusable-semgrep.yml@main`
- Replace `trivy.yml` with thin caller to `Forge-Space/.github/.github/workflows/reusable-trivy.yml@main`
- Replace `secret-scan.yml` with thin caller to `Forge-Space/.github/.github/workflows/reusable-secret-scan.yml@main`

All security scanning logic now maintained centrally in the org `.github` repo.

## Test plan
- [x] Verify workflows validate (GitHub Actions syntax)
- [ ] Verify Semgrep runs on PR
- [ ] Verify Trivy runs on PR
- [ ] Verify Secret Scanning runs on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)