### PR TITLE
fix: expand SonarCloud CPD exclusions to all registry data files

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,3 @@
 sonar.projectKey=Forge-Space_siza-gen
 sonar.organization=forge-space
-sonar.cpd.exclusions=src/registry/component-registry/molecules/ai-patterns.ts,src/registry/component-registry/molecules/data-display.ts,src/registry/component-registry/molecules/dashboards.ts,src/registry/component-registry/molecules/settings.ts,src/registry/component-registry/organisms/dashboards.ts,src/registry/component-registry/organisms/settings.ts
+sonar.cpd.exclusions=src/registry/component-registry/**/*.ts,src/component-libraries/**/templates.ts


### PR DESCRIPTION
Registry component definitions have inherently repetitive structure. Expand CPD exclusion glob to cover all component-registry/**/*.ts and PrimeVue template files. Unblocks #40.