### PR TITLE
chore: adopt org-level PR governance and stale management

### DIFF
--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -1,0 +1,10 @@
+name: PR Governance
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+# Security: No user-controlled inputs used in run: commands.
+
+jobs:
+  governance:
+    uses: Forge-Space/.github/.github/workflows/reusable-pr-governance.yml@main

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,12 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+# Security: No user-controlled inputs used in run: commands.
+
+jobs:
+  stale:
+    uses: Forge-Space/.github/.github/workflows/reusable-stale.yml@main


### PR DESCRIPTION
## What

Adopts the org-level reusable workflows from Forge-Space/.github.

## Why

Standardizes PR governance across all Forge Space repos per .github PR #7.

## How

- `pr-governance.yml`: PR size labels (XS-XL) + conventional commit title lint
- `stale.yml`: Auto-mark stale issues/PRs after 30 days, close after 14 more

## Type
- [x] chore: Maintenance (deps, CI, config)

## Test plan
- [x] No tests needed (docs/config only)

## Checklist
- [x] Self-review completed
- [x] No secrets or credentials committed