### PR TITLE
docs(specs): bootstrap spec and roadmap flow

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,15 @@
+# Roadmap - siza-gen
+
+_Auto-regenerated 2026-04-15 from `docs/specs/`._
+
+## Now (active)
+
+_(none)_
+
+## Next (proposed)
+
+- **2026-04-15-generator-roadmap-specs**  _(proposed)_  `roadmap,specs,generator`
+
+## Recently shipped
+
+_(none)_

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,7 +8,7 @@ _(none)_
 
 ## Next (proposed)
 
-- **2026-04-15-generator-roadmap-specs**  _(proposed)_  `roadmap,specs,generator`
+- **2026-04-15-generator-roadmap-specs** _(proposed)_ `roadmap,specs,generator`
 
 ## Recently shipped
 

--- a/docs/specs/2026-04-15-generator-roadmap-specs/spec.md
+++ b/docs/specs/2026-04-15-generator-roadmap-specs/spec.md
@@ -1,0 +1,21 @@
+---
+status: proposed
+created: 2026-04-15
+owner: lucassantana
+pr:
+tags: roadmap,specs,generator
+---
+
+# generator-roadmap-specs
+
+## Goal
+Track Siza generator improvements through committed specs instead of transient session plans.
+
+## Context
+siza-gen drives CLI/template behavior where small changes affect downstream projects. Persistent specs make release intent and task state retrievable.
+
+## Approach
+Add a proposed adoption spec, derive docs/roadmap.md from specs, and use future specs for template, CLI, and release work.
+
+## Verification
+The roadmap surfaces the proposed generator spec and the files are available for RAG context packs.

--- a/docs/specs/2026-04-15-generator-roadmap-specs/spec.md
+++ b/docs/specs/2026-04-15-generator-roadmap-specs/spec.md
@@ -9,13 +9,21 @@ tags: roadmap,specs,generator
 # generator-roadmap-specs
 
 ## Goal
-Track Siza generator improvements through committed specs instead of transient session plans.
+
+Track Siza generator improvements through committed specs instead of transient
+session plans.
 
 ## Context
-siza-gen drives CLI/template behavior where small changes affect downstream projects. Persistent specs make release intent and task state retrievable.
+
+siza-gen drives CLI/template behavior where small changes affect downstream
+projects. Persistent specs make release intent and task state retrievable.
 
 ## Approach
-Add a proposed adoption spec, derive docs/roadmap.md from specs, and use future specs for template, CLI, and release work.
+
+Add a proposed adoption spec, derive docs/roadmap.md from specs, and use future
+specs for template, CLI, and release work.
 
 ## Verification
-The roadmap surfaces the proposed generator spec and the files are available for RAG context packs.
+
+The roadmap surfaces the proposed generator spec and the files are available for
+RAG context packs.

--- a/docs/specs/2026-04-15-generator-roadmap-specs/tasks.md
+++ b/docs/specs/2026-04-15-generator-roadmap-specs/tasks.md
@@ -1,0 +1,7 @@
+# Tasks - generator-roadmap-specs
+
+- [ ] Review current roadmap/backlog signals for the repo
+- [ ] Convert the next non-trivial feature into a focused spec
+- [ ] Keep docs/roadmap.md generated from specs, not hand-edited
+- [ ] Verify RAG returns this spec via source_type=spec or roadmap
+- [ ] Link the implementation PR before marking shipped


### PR DESCRIPTION
## Summary
- seed Agent-OS-style feature spec placeholder
- generate docs/roadmap.md from spec frontmatter
- make the repo visible to the shared RAG spec/roadmap workflow

## Verification
- docs-only change; inspected generated roadmap and spec layout
